### PR TITLE
LGPD updated starting month

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For more detail about a country's legislation, click the country name.
 | Country| Legislation | Content required| Opt-out required| Consent required | Penalties|
 | ------------- | ------------- | ------------- | ------------- |-------------  | -------------|
 | [Australia](/country/australia.md)  | Spam Act 2003 | Name, contact information| Yes| Implied consent if you have a previous business relationship. Otherwise, explicit | Up to $1.8m AUD per day |
-| [Brazil](/country/brazil.md)  | None at present, LGPD comes in February 2020 | None | No| Consent is not required | None |
+| [Brazil](/country/brazil.md)  | None at present, LGPD comes in August 2020 | None | No| Consent is not required | None |
 | [Canada](/country/canada.md)  | CASL | Name, mailing address, contact information| Yes| Implied consent if you have a previous business relationship. Otherwise, explicit | Up to $10m CAD per violation |
 | [Germany](/country/germany.md)  | Federal Data Protection Act, GDPR, Telemedia Act | Name, mailing address, clear identification of the sender| Yes| Implied consent if you have a previous business relationship. Otherwise, explicit | Up to €20m, or 4% annual global turnover – whichever is higher |
 | [India](/country/india.md)  | None at present | None | No| Consent is not required | None |


### PR DESCRIPTION
[MPV 869/2018](https://www.congressonacional.leg.br/materias/medidas-provisorias/-/mpv/135062)

The original period of vacatio legis was extended from 18 months to 24 months, from
August 2018.